### PR TITLE
[MLR-255] Revert "rt: reduce no-op wakeups in the multi-threaded scheduler (#4383)"

### DIFF
--- a/tokio/src/runtime/thread_pool/idle.rs
+++ b/tokio/src/runtime/thread_pool/idle.rs
@@ -64,7 +64,7 @@ impl Idle {
 
         // A worker should be woken up, atomically increment the number of
         // searching workers as well as the number of unparked workers.
-        State::unpark_one(&self.state, 1);
+        State::unpark_one(&self.state);
 
         // Get the worker to unpark
         let ret = sleepers.pop();
@@ -111,9 +111,7 @@ impl Idle {
 
     /// Unpark a specific worker. This happens if tasks are submitted from
     /// within the worker's park routine.
-    ///
-    /// Returns `true` if the worker was parked before calling the method.
-    pub(super) fn unpark_worker_by_id(&self, worker_id: usize) -> bool {
+    pub(super) fn unpark_worker_by_id(&self, worker_id: usize) {
         let mut sleepers = self.sleepers.lock();
 
         for index in 0..sleepers.len() {
@@ -121,13 +119,11 @@ impl Idle {
                 sleepers.swap_remove(index);
 
                 // Update the state accordingly while the lock is held.
-                State::unpark_one(&self.state, 0);
+                State::unpark_one(&self.state);
 
-                return true;
+                return;
             }
         }
-
-        false
     }
 
     /// Returns `true` if `worker_id` is contained in the sleep set.
@@ -155,8 +151,8 @@ impl State {
         State(cell.load(ordering))
     }
 
-    fn unpark_one(cell: &AtomicUsize, num_searching: usize) {
-        cell.fetch_add(num_searching | (1 << UNPARK_SHIFT), SeqCst);
+    fn unpark_one(cell: &AtomicUsize) {
+        cell.fetch_add(1 | (1 << UNPARK_SHIFT), SeqCst);
     }
 
     fn inc_num_searching(cell: &AtomicUsize, ordering: Ordering) {


### PR DESCRIPTION

This reverts commit 4eed411519783ef6f58cbf74f886f91142b5cfa6.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
